### PR TITLE
close the connection when 403ing - fixes issue #35

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ app.post('/slack', function (req, res) {
       res.send(400);
     });
   } else {
-    res.status(403);
+    res.status(403).end();
   }
 });
 


### PR DESCRIPTION
Small bug fix to close HTTP connection when invalid Slack slash commands arrive