### PR TITLE
Added answer label to answer count

### DIFF
--- a/public/home.html
+++ b/public/home.html
@@ -120,7 +120,7 @@
               <a class="owner" :href="doc.question.owner.link" target="_new" title="question owner and reputation">{{ doc.question.owner.display_name }} ({{ doc.question.owner.reputation }})</a>
         </div>
         <div class="col-xs-2 col-md-1">
-          <span class="badge" title="answers">{{ doc.question.answer_count }}</span>
+          <span class="badge" title="answers">{{ doc.question.answer_count }} Answers</span>
           <span v-if="doc.answered" class="badge answered" title="already answered!"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></span>
           <span v-if="doc.rejected" class="badge rejected"><span class="glyphicon glyphicon-remove" aria-hidden="true"></span></span>
         </div>


### PR DESCRIPTION
I've created a temporary fix to Issue #59 by adding the word "Answers" after the answer count within the existing bubble. This is the column where the meaning of the contents is least obvious, so it's a good temporary fix.

I'll be playing around later to see if I can make meaningful column headers for all of the columns as a more complete solution.