### PR TITLE
added design document for the dashboard - speeds up page load - fixes…

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -61,6 +61,49 @@ sodb.update(customtagsddoc).then(function() {
   console.log('design doc created');
 });
 
+
+// dashboard design documents
+var alltickets = function(doc) {
+  if (doc.question) {
+    emit(doc.question.creation_date, null);
+  }
+};
+var mytickets = function(doc) {
+  if (doc.question && 
+     (typeof doc.rejected === 'undefined' || doc.rejected === false) && 
+     (typeof doc.answered === 'undefined' || doc.answered === false) &&
+     doc.owner !== null) {
+    emit(doc.owner, null);
+  }
+};
+var unassignedtickets = function(doc) {
+  if (!doc.rejected && !doc.answered && doc.owner === null) {
+    emit(doc.question.creation_date, null);
+  }
+};
+var dashboarddoc = {
+  _id: '_design/dashboard',
+  views: {
+    alltickets: {
+      map: alltickets.toString()
+    },
+    mytickets: {
+      map: mytickets.toString()
+    },
+    unassignedtickets: {
+      map: unassignedtickets.toString()
+    }
+  },
+  language: "javascript"
+};
+console.log(dashboarddoc);
+sodb.update(dashboarddoc).then(function() {
+  console.log('dashboard design doc created');
+});
+
+
+
+
 module.exports = {
   tokens: tokensdb,
   so: sodb,

--- a/public/js/sodashboard.js
+++ b/public/js/sodashboard.js
@@ -192,14 +192,8 @@ var app = new Vue({
 
     },
     allTickets: function() {
-     // load tickets assigned to me  
-      var map = function(doc) {
-        if (doc.question) {
-          emit(doc.question.creation_date, null);
-        }
-      };
       // get list of unassigned tickets, newest first
-      db.query(map, {descending:true, include_docs:true}).then(function(data) {
+      db.query('dashboard/alltickets', {descending:true, include_docs:true}).then(function(data) {
         app.docs = [];
         for(var i in data.rows) {
           app.docs.push(data.rows[i].doc);
@@ -208,17 +202,8 @@ var app = new Vue({
       });
     },
     myTickets: function() {
-     // load tickets assigned to me  
-      var map = function(doc) {
-        if (doc.question && 
-             (typeof doc.rejected === 'undefined' || doc.rejected === false) && 
-             (typeof doc.answered === 'undefined' || doc.answered === false) &&
-             doc.owner !== null) {
-          emit(doc.owner, null);
-        }
-      };
       // get list of unassigned tickets, newest first
-      db.query(map, {key: app.loggedinuser._id, include_docs:true}).then(function(data) {
+      db.query('dashboard/mytickets', {key: app.loggedinuser._id, include_docs:true}).then(function(data) {
         app.docs = [];
         for(var i in data.rows) {
           app.docs.push(data.rows[i].doc);
@@ -227,14 +212,8 @@ var app = new Vue({
       });
     },
     unAssignedTickets: function() {
-      // load unassigned tickets
-      var map = function(doc) {
-        if (!doc.rejected && !doc.answered && doc.owner === null) {
-          emit(doc.question.creation_date, null);
-        }
-      };
       // get list of unassigned tickets, newest first
-      db.query(map, {include_docs:true, descending: true}).then(function(data) {
+      db.query('dashboard/unassignedtickets', {include_docs:true, descending: true}).then(function(data) {
         console.log('unAssignedTickets', data);
         app.docs = [];
         for(var i in data.rows) {


### PR DESCRIPTION
… issue #58

This PR

- makes the app create a `_design/dashboard` design document on startup with three views
- modifies the front-end app to use the design document instead of hard-coded map functions.

The All, My tickets and Unassigned tickets views should all work on the front end.