### PR TITLE
added v-cloak to prevent vue.js app being displayed until ready - fix…

### DIFF
--- a/public/css/sodashboard.css
+++ b/public/css/sodashboard.css
@@ -160,3 +160,7 @@ body {
 .syncerror {
   color: red;
 }
+
+[v-cloak] {
+  display: none;
+}

--- a/public/home.html
+++ b/public/home.html
@@ -13,7 +13,7 @@
  <link rel="stylesheet" href="css/sodashboard.css">
 </head>
 <body>
-  <div id="app">
+  <div id="app" v-cloak>
 
     <nav class="navbar navbar-inverse navbar-fixed-top">
       <div class="container-fluid">


### PR DESCRIPTION
…es issue #57 

- added `v-cloak` directive to the #app div
- add CSS to hide the div on startup

This prevents you seeing `{{ x }}` placeholders on page load as per [this documentation](https://vuejs.org/v2/api/#v-cloak)