### PR TITLE
Add symbol key

### DIFF
--- a/public/home.html
+++ b/public/home.html
@@ -77,7 +77,7 @@
                 <div class="col-md-10">
                     <h2>{{ mode }} tickets <span class="badge" v-if="numDocs">{{ docs.length }}</span></h2>
                     <!-- Symbol Key -->
-                    <div id=symbolkey>
+                    <div id="symbolkey">
                         <p>
                             <span title="already answered!" class="badge answered"><span aria-hidden="true" class="glyphicon glyphicon-ok"></span></span> Answered   
                             <span class="badge rejected"><span aria-hidden="true" class="glyphicon glyphicon-remove"></span></span> Rejected 

--- a/public/home.html
+++ b/public/home.html
@@ -77,8 +77,15 @@
                 <div class="col-md-10">
                     <h2>{{ mode }} tickets <span class="badge" v-if="numDocs">{{ docs.length }}</span></h2>
                     <!-- Symbol Key -->
-                    <p><span title="already answered!" class="badge answered"><span aria-hidden="true" class="glyphicon glyphicon-ok"></span></span> Answered   
-                    <span class="badge rejected"><span aria-hidden="true" class="glyphicon glyphicon-remove"></span></span> Rejected</p>
+                    <div id=symbolkey>
+                        <p>
+                            <span title="already answered!" class="badge answered"><span aria-hidden="true" class="glyphicon glyphicon-ok"></span></span> Answered   
+                            <span class="badge rejected"><span aria-hidden="true" class="glyphicon glyphicon-remove"></span></span> Rejected 
+                            <span class="label label-default tag">SO Tag</span> 
+                            <span class="ctag">Custom Tag</span> 
+                        </p>
+                    </div>
+
                 </div>
                 <div class="col-md-2">
                     <h2>

--- a/public/home.html
+++ b/public/home.html
@@ -76,6 +76,9 @@
             <div class="row">
                 <div class="col-md-10">
                     <h2>{{ mode }} tickets <span class="badge" v-if="numDocs">{{ docs.length }}</span></h2>
+                    <!-- Symbol Key -->
+                    <p><span title="already answered!" class="badge answered"><span aria-hidden="true" class="glyphicon glyphicon-ok"></span></span> Answered   
+                    <span class="badge rejected"><span aria-hidden="true" class="glyphicon glyphicon-remove"></span></span> Rejected</p>
                 </div>
                 <div class="col-md-2">
                     <h2>


### PR DESCRIPTION
Placed under the "Unassigned Tags" header, this symbol key shows the meaning of the checkmarks (answered), Xs (rejected), dark gray tags (SO-created), and light gray tags (user-created).

This new div should be easy to later move into the gray bar on the new UI @rajrsingh is working on.