### PR TITLE
Moved location of sync status

### DIFF
--- a/public/home.html
+++ b/public/home.html
@@ -28,19 +28,7 @@
             <span class="icon-bar"></span>
           </button>
                     <a v-on:click="mode='unassigned'" class="navbar-brand" href="#unassigned">SO Dashboard</a>
-                    <div id="syncStatus">
-                        <span v-if="syncInProgress">
-              <span class="glyphicon glyphicon-flash" aria-hidden="true"></span>
-                        </span>
-                        <span v-if="syncError" class="syncerror">
-              <span class="glyphicon glyphicon-ban-circle" aria-hidden="true"></span>
-                        </span>
-                        <span v-if="syncComplete">
-              <span class="glyphicon glyphicon-ok" aria-hidden="true"></span>
-                        </span>
-                        <span class="badge" v-if="numDocs">{{ numDocs }}</span>
-                    </div>
-                    <!--syncStatus -->
+
                 </div>
 
                 <!-- Collect the nav links, forms, and other content for toggling -->
@@ -57,6 +45,22 @@
                         <button type="submit" class="btn btn-default">Search</button>
                     </form>
                     <ul class="nav navbar-nav navbar-right">
+                        <li>
+                        <!--syncStatus -->
+                            <div id="syncStatus">
+                            <span v-if="syncInProgress">
+                            <span class="glyphicon glyphicon-flash" aria-hidden="true"></span>
+                            </span>
+                            <span v-if="syncError" class="syncerror">
+                            <span class="glyphicon glyphicon-ban-circle" aria-hidden="true"></span>
+                            </span>
+                            <span v-if="syncComplete">
+                            <span class="glyphicon glyphicon-ok" aria-hidden="true"></span>
+                            </span>
+                            <span class="badge" v-if="numDocs">{{ numDocs }}</span>
+                            </div>
+                    
+                        </li>
                         <li>
                             <div id="loggedinuser" v-if="loggedinuser">
                                 <a v-on:click="profileEditor" href="#profile">


### PR DESCRIPTION
This PR solves Issue #82 by moving the sync status icon so it sits on the right half of the top nav, just to the left of the user ID, as @rajrsingh requested.

I was able to accomplish this by just moving the <div> for the sync status to a different place in the code and putting it inside an <li>. 

Here's a screenshot of what this looks like: 
![image](https://user-images.githubusercontent.com/19171465/28645447-86ae75d8-722b-11e7-8852-cd5d1d0dfc6f.png)
