### PR TITLE
[WIP] Travis integration for deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+  - "node"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,7 @@ before_deploy:
 - mv linux64 Bluemix_CLI.tar.gz
 - tar -xzvf Bluemix_CLI.tar.gz
 - chmod a+x Bluemix_CLI/bin/bluemix
-- ./Bluemix_CLI/bin/bluemix --version
-- ./Bluemix_CLI/bin/bluemix update
+- ./Bluemix_CLI/bin/bluemix config --check-version false
 - ./Bluemix_CLI/bin/bluemix api https://api.ng.bluemix.net
 - ./Bluemix_CLI/bin/bluemix login --apikey $BXIAM
 - ./Bluemix_CLI/bin/bluemix target -o Watson-Data-Lab -s stackoverflow

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ before_deploy:
 - ./Bluemix_CLI/bin/bluemix api https://api.ng.bluemix.net
 - ./Bluemix_CLI/bin/bluemix login --apikey $BXIAM
 - ./Bluemix_CLI/bin/bluemix target -o Watson-Data-Lab -s stack-overflow
-- ./Bluemix_CLI/bin/bluemix set-env sodashboard-beta CLOUDANT_URL $CLOLUDANT_URL
-- ./Bluemix_CLI/bin/bluemix set-env sodashboard-beta CLOUDANT_DB $CLOLUDANT_DB
+- ./Bluemix_CLI/bin/bluemix cf set-env sodashboard-beta CLOUDANT_URL $CLOLUDANT_URL
+- ./Bluemix_CLI/bin/bluemix cf set-env sodashboard-beta CLOUDANT_DB $CLOLUDANT_DB
 - ./Bluemix_CLI/bin/bluemix cf push
 
 deploy: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ before_deploy:
 - tar -xzvf Bluemix_CLI.tar.gz
 - chmod a+x Bluemix_CLI/bin/bluemix
 - ./Bluemix_CLI/bin/bluemix --version
+- ./Bluemix_CLI/bin/bluemix update
 - ./Bluemix_CLI/bin/bluemix api https://api.ng.bluemix.net
 - ./Bluemix_CLI/bin/bluemix login --apikey $BXIAM
 - ./Bluemix_CLI/bin/bluemix target -o Watson-Data-Lab -s stackoverflow

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,13 @@
 language: node_js
+sudo: required
 node_js:
 - node
 before_deploy: 
-  - wget https://clis.ng.bluemix.net/download/bluemix-cli/0.6.1/linux64
-  - mv linux64 Bluemix_CLI.tar.gz
-  - tar -xzvf Bluemix_CLI.tar.gz
-  - cd Bluemix_CLI
-  - sudo ./install_bluemix_cli
-  - bx --version
 deploy: 
-  script: echo "I am deploying"
+  provider: script
+  script: deploy.sh
   on:
     repo: ibm-watson-data-lab/sodashboard
     branch: travis
+  skip_cleanup: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,4 @@ node_js:
 before_deploy: 
 - curl -fsSL https://clis.ng.bluemix.net/install/linux | sh
 - bx --version
-deploy:
-- echo "I am deploying"
+deploy: echo "I am deploying"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
 - node
 before_deploy: 
-  curl -fsSL https://clis.ng.bluemix.net/install/linux | sh
-  bx --version
+- curl -fsSL https://clis.ng.bluemix.net/install/linux | sh
+- bx --version
 deploy:
-  echo "I am deploying"
+- echo "I am deploying"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,10 @@ before_deploy:
 - ./Bluemix_CLI/bin/bluemix api https://api.ng.bluemix.net
 - ./Bluemix_CLI/bin/bluemix login --apikey $BXIAM
 - ./Bluemix_CLI/bin/bluemix target -o Watson-Data-Lab -s stack-overflow
+- ./Bluemix_CLI/bin/bluemix set-env sodashboard-beta CLOUDANT_URL $CLOLUDANT_URL
+- ./Bluemix_CLI/bin/bluemix set-env sodashboard-beta CLOUDANT_DB $CLOLUDANT_DB
+- ./Bluemix_CLI/bin/bluemix cf push
+
 deploy: 
   provider: script
   script: deploy.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ node_js:
 before_install:
 - set verbose_script_output "true"
 before_deploy: 
+- set verbose_script_output "true"
 - echo "Stand by..."
 - wget https://clis.ng.bluemix.net/download/bluemix-cli/0.6.1/linux64
 - mv linux64 Bluemix_CLI.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_deploy:
 - ./Bluemix_CLI/bin/bluemix config --check-version false
 - ./Bluemix_CLI/bin/bluemix api https://api.ng.bluemix.net
 - ./Bluemix_CLI/bin/bluemix login --apikey $BXIAM
-- ./Bluemix_CLI/bin/bluemix target -o Watson-Data-Lab -s stackoverflow
+- ./Bluemix_CLI/bin/bluemix target -o Watson-Data-Lab -s stack-overflow
 deploy: 
   provider: script
   script: deploy.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,9 @@ before_deploy:
 - tar -xzvf Bluemix_CLI.tar.gz
 - chmod a+x Bluemix_CLI/bin/bluemix
 - ./Bluemix_CLI/bin/bluemix --version
+- ./Bluemix_CLI/bin/bluemix api https://api.ng.bluemix.net
 - ./Bluemix_CLI/bin/bluemix login --apikey $BXIAM
+- ./Bluemix_CLI/bin/bluemix target -o Watson-Data-Lab -s stackoverflow
 deploy: 
   provider: script
   script: deploy.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,11 @@ language: node_js
 node_js:
 - node
 before_deploy: 
-  - curl -fsSL https://clis.ng.bluemix.net/install/linux | sh
+  - wget https://clis.ng.bluemix.net/download/bluemix-cli/0.6.1/linux64
+  - mv linux64 Bluemix_CLI.tar.gz
+  - tar -xzvf Bluemix_CLI.tar.gz
+  - cd Bluemix_CLI
+  - sudo ./install_bluemix_cli
   - bx --version
 deploy: 
   script: echo "I am deploying"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,10 @@ language: node_js
 sudo: required
 node_js:
 - node
+before_install:
+- set verbose_script_output "true"
 before_deploy: 
+- echo "Stand by..."
 deploy: 
   provider: script
   script: deploy.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,5 @@ node_js:
 before_deploy: 
 - curl -fsSL https://clis.ng.bluemix.net/install/linux | sh
 - bx --version
-deploy: echo "I am deploying"
+deploy: 
+- script: echo "I am deploying"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,11 @@ language: node_js
 node_js:
 - node
 before_deploy: 
-- curl -fsSL https://clis.ng.bluemix.net/install/linux | sh
-- bx --version
+  - curl -fsSL https://clis.ng.bluemix.net/install/linux | sh
+  - bx --version
 deploy: 
-- script: echo "I am deploying"
+  script: echo "I am deploying"
+  on:
+    repo: ibm-watson-data-lab/sodashboard
+    branch: travis
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ before_deploy:
 - ./Bluemix_CLI/bin/bluemix api https://api.ng.bluemix.net
 - ./Bluemix_CLI/bin/bluemix login --apikey $BXIAM
 - ./Bluemix_CLI/bin/bluemix target -o Watson-Data-Lab -s stack-overflow
-- ./Bluemix_CLI/bin/bluemix cf set-env sodashboard-beta CLOUDANT_URL $CLOLUDANT_URL
-- ./Bluemix_CLI/bin/bluemix cf set-env sodashboard-beta CLOUDANT_DB $CLOLUDANT_DB
+- ./Bluemix_CLI/bin/bluemix cf set-env sodashboard-beta CLOUDANT_URL $CLOUDANT_URL
+- ./Bluemix_CLI/bin/bluemix cf set-env sodashboard-beta CLOUDANT_DB $CLOUDANT_DB
 - ./Bluemix_CLI/bin/bluemix cf push
 
 deploy: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,14 @@
 language: node_js
 node_js:
-  - "node"
+- node
+deploy:
+  provider: cloudfoundry
+  api: https://api.ng.bluemix.net
+  username: lorna.mitchell@uk.ibm.com
+  password:
+    secure: DlrYGAb/ITheFqhkh7rSvxuVE+5Iwwsj2vVPEJltUztX7Aq/38RABCTg8nRe9mqDBRUdapwqxHye+drTys2BNT2BrXmUzAnth7kIY+pDXBUkHWywoXbqx9DKLhpCvgTZqxsqoEO8iGgKDMgIsSA/3hZBe2Vd1UIlUAiWz1XVnSJeqQgKcsEJ8Cp1QzbEA1t84NNKE0zaYMur0ermI+8GDnDSB+bkTSM8PDSELfSExsSBFCzo12S7714s4+ja8lLIyXpR3AbM1Gq/uyCezsOCXV8zhi1tUwiTzxpJLFdYvmrN4JI9IqlKafeHf6vHgKy9TmVXNs3pwXeoe1YUY7I8IrYQMuAseLqFHU8HXicMXeSq+KHN3ibi1HvS6sBAuqsB9whp9LGlq4yngI/aw7e99RwZ7G/N0lBX7PhjPLTm3r0UQWLwuuyASljz1DqSJGE6KC42JraD382gFvwHIptL8MwKQmJ0Jif5F1+Bw9idZQTHtKxjy5gkdHzD4I3W/QHiGtbf/insdEpygbyMNe897BlFYp2RXgk/AlRhxPBotev/0wd6qxfDzN2EO2bWfh3kr3J264Joa6l5BRyqQj5VLB9DG0q53in3Q0JhzTC9eI/ZKpcN+C0W/Lo6lXHpa1G/J8MIPRzn3HA0XP8r3KhxSecpqIBOjqNem7Zcz1Ah0Cc=
+  organization: Watson-Data-Lab
+  space: stack-overflow
+  on:
+    repo: ibm-watson-data-lab/sodashboard
+    branch: travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,11 @@ before_install:
 - set verbose_script_output "true"
 before_deploy: 
 - echo "Stand by..."
+- wget https://clis.ng.bluemix.net/download/bluemix-cli/0.6.1/linux64
+- mv linux64 Bluemix_CLI.tar.gz
+- tar -xzvf Bluemix_CLI.tar.gz
+- chmod a+x Bluemix_CLI/bin/bluemix
+- ./Bluemix_CLI/bin/bluemix --version
 deploy: 
   provider: script
   script: deploy.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,14 @@ language: node_js
 sudo: required
 node_js:
 - node
-before_install:
-- set verbose_script_output "true"
 before_deploy: 
-- set verbose_script_output "true"
 - echo "Stand by..."
 - wget https://clis.ng.bluemix.net/download/bluemix-cli/0.6.1/linux64
 - mv linux64 Bluemix_CLI.tar.gz
 - tar -xzvf Bluemix_CLI.tar.gz
 - chmod a+x Bluemix_CLI/bin/bluemix
 - ./Bluemix_CLI/bin/bluemix --version
+- ./Bluemix_CLI/bin/bluemix login --apikey $BXIAM
 deploy: 
   provider: script
   script: deploy.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,8 @@
 language: node_js
 node_js:
 - node
+before_deploy: 
+  curl -fsSL https://clis.ng.bluemix.net/install/linux | sh
+  bx --version
 deploy:
-  provider: cloudfoundry
-  api: https://api.ng.bluemix.net
-  username: lorna.mitchell@uk.ibm.com
-  password:
-    secure: DlrYGAb/ITheFqhkh7rSvxuVE+5Iwwsj2vVPEJltUztX7Aq/38RABCTg8nRe9mqDBRUdapwqxHye+drTys2BNT2BrXmUzAnth7kIY+pDXBUkHWywoXbqx9DKLhpCvgTZqxsqoEO8iGgKDMgIsSA/3hZBe2Vd1UIlUAiWz1XVnSJeqQgKcsEJ8Cp1QzbEA1t84NNKE0zaYMur0ermI+8GDnDSB+bkTSM8PDSELfSExsSBFCzo12S7714s4+ja8lLIyXpR3AbM1Gq/uyCezsOCXV8zhi1tUwiTzxpJLFdYvmrN4JI9IqlKafeHf6vHgKy9TmVXNs3pwXeoe1YUY7I8IrYQMuAseLqFHU8HXicMXeSq+KHN3ibi1HvS6sBAuqsB9whp9LGlq4yngI/aw7e99RwZ7G/N0lBX7PhjPLTm3r0UQWLwuuyASljz1DqSJGE6KC42JraD382gFvwHIptL8MwKQmJ0Jif5F1+Bw9idZQTHtKxjy5gkdHzD4I3W/QHiGtbf/insdEpygbyMNe897BlFYp2RXgk/AlRhxPBotev/0wd6qxfDzN2EO2bWfh3kr3J264Joa6l5BRyqQj5VLB9DG0q53in3Q0JhzTC9eI/ZKpcN+C0W/Lo6lXHpa1G/J8MIPRzn3HA0XP8r3KhxSecpqIBOjqNem7Zcz1Ah0Cc=
-  organization: Watson-Data-Lab
-  space: stack-overflow
-  on:
-    repo: ibm-watson-data-lab/sodashboard
-    branch: travis
+  echo "I am deploying"

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+wget https://clis.ng.bluemix.net/download/bluemix-cli/0.6.1/linux64
+mv linux64 Bluemix_CLI.tar.gz
+tar -xzvf Bluemix_CLI.tar.gz
+cd Bluemix_CLI
+sudo ./install_bluemix_cli
+bx --version
+

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,9 +1,3 @@
 #!/bin/bash
 
-wget https://clis.ng.bluemix.net/download/bluemix-cli/0.6.1/linux64
-mv linux64 Bluemix_CLI.tar.gz
-tar -xzvf Bluemix_CLI.tar.gz
-cd Bluemix_CLI
-sudo ./install_bluemix_cli
-bx --version
-
+echo "Deploying ..."

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-echo "Deploying ..."
+# do nothing, we're good

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,5 +1,5 @@
 applications:
-- name: sodashboard
+- name: sodashboard-beta
   memory: 512M
   instances: 1
   domain: mybluemix.net

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Stack Overflow Dashboard",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "echo \"Error: no test specified\"",
     "start": "node index.js"
   },
   "repository": {


### PR DESCRIPTION
Add travis deployment to the dashboard for deploying to our new space (the previous version used the Bluemix deployment mechanism).

Current issues:
 - the actual deploy script contains only an echo script but this causes an error so the overall build task always shows as failed
 - the actual work is in the `before_deploy` section because this seems to give more output in the travis web interface than the script can do (but press the "Raw" button in the web interface to get the real log
 - the `bx` command is working but commands starting `bx cf` do not work.

Alternative approach:
 - try again to use a cloudfoundry mechanism, apparently we can use username "apikey" and an API key to log in  .... but we'll need working `bx` for the `soingest` project so it seemed worth pursuing this route if we can.