### PR TITLE
Enable auto-deployment to IBM Cloud using Travis CI

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,1 +1,3 @@
 .gitignore
+.travis.yml
+deploy.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ node_js:
 - node
 before_deploy: 
 - curl -L https://clis.ng.bluemix.net/download/bluemix-cli/0.6.1/linux64 | tar -zx
+- chmod -R u+x Bluemix_CLI/bin
 deploy: 
   provider: script
   script: deploy.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,5 @@ deploy:
   script: ./deploy.sh
   on:
     repo: ibm-watson-data-lab/sodashboard
-    branch: travis_test
+    branch: master
   skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ node_js:
 before_deploy: 
 - curl -L https://clis.ng.bluemix.net/download/bluemix-cli/0.6.1/linux64 | tar -zx
 - chmod -R u+x ./Bluemix_CLI/bin
+- chmod +x ./deploy.sh
 deploy: 
   provider: script
   script: ./deploy.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: node_js
+sudo: required
+node_js:
+- node
+before_deploy: 
+- curl -L https://clis.ng.bluemix.net/download/bluemix-cli/0.6.1/linux64 | tar -zx
+deploy: 
+  provider: script
+  script: deploy.sh
+  on:
+    repo: ibm-watson-data-lab/sodashboard
+    branch: travis_test
+  skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ node_js:
 - node
 before_deploy: 
 - curl -L https://clis.ng.bluemix.net/download/bluemix-cli/0.6.1/linux64 | tar -zx
-- chmod -R u+x Bluemix_CLI/bin
+- chmod -R u+x ./Bluemix_CLI/bin
 deploy: 
   provider: script
-  script: deploy.sh
+  script: ./deploy.sh
   on:
     repo: ibm-watson-data-lab/sodashboard
     branch: travis_test

--- a/deploy.sh
+++ b/deploy.sh
@@ -2,13 +2,13 @@
 
 # verify that the required Cloud Foundry variables are set
 # - BXIAM: IBM Cloud API key
-if [ -z ${BXIAM+x} ]; then echo 'Environment variable BXIAM is undefined.'; return 1; fi
+if [ -z ${BXIAM+x} ]; then echo 'Environment variable BXIAM is undefined.'; exit 1; fi
 # - CF_ORGANIZATION: IBM Cloud/Cloud Foundry organization name
-if [ -z ${CF_ORGANIZATION+x} ]; then echo 'Environment variable CF_ORGANIZATION is undefined.'; return 1; fi
+if [ -z ${CF_ORGANIZATION+x} ]; then echo 'Environment variable CF_ORGANIZATION is undefined.'; exit 1; fi
 # - CF_SPACE: IBM Cloud/Cluod Foundry space name
-if [ -z ${CF_SPACE+x} ]; then echo 'Environment variable CF_SPACE is undefined.'; return 1; fi
+if [ -z ${CF_SPACE+x} ]; then echo 'Environment variable CF_SPACE is undefined.'; exit 1; fi
 # - APP_NAME: IBM Cloud/Cluod Foundry application name
-if [ -z ${APP_NAME+x} ]; then echo 'Environment variable APP_NAME is undefined.'; return 1; fi
+if [ -z ${APP_NAME+x} ]; then echo 'Environment variable APP_NAME is undefined.'; exit 1; fi
 
 # set optional Cloud Foundry variables if they are not set
 # - CF_API: IBM Cloud API endpoint (default to US-South region)
@@ -16,9 +16,9 @@ if [ -z ${CF_API+x} ]; then export CF_API='https://api.ng.bluemix.net'; fi
 
 # verify that the required application specific variables are set
 # - refer to documentation
-if [ -z ${CLOUDANT_URL+x} ]; then echo 'Environment variable CLOUDANT_URL is undefined.'; return 1; fi
-if [ -z ${CLOUDANT_DB+x} ]; then echo 'Environment variable CLOUDANT_DB is undefined.'; return 1; fi
-if [ -z ${SLACK_TOKEN+x} ]; then echo 'Environment variable SLACK_TOKEN is undefined.'; return 1; fi
+if [ -z ${CLOUDANT_URL+x} ]; then echo 'Environment variable CLOUDANT_URL is undefined.'; exit 1; fi
+if [ -z ${CLOUDANT_DB+x} ]; then echo 'Environment variable CLOUDANT_DB is undefined.'; exit 1; fi
+if [ -z ${SLACK_TOKEN+x} ]; then echo 'Environment variable SLACK_TOKEN is undefined.'; exit 1; fi
 
 # login and set target
 ./Bluemix_CLI/bin/bluemix config --check-version false

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,8 +1,28 @@
 #!/bin/bash
 
+# verify that the required Cloud Foundry variables are set
+# - BXIAM: IBM Cloud API key
+if [ -z ${BXIAM+x} ]; then echo 'Environment variable BXIAM is undefined.'; return 1; fi
+# - CF_ORGANIZATION: IBM Cloud/Cloud Foundry organization name
+if [ -z ${CF_ORGANIZATION+x} ]; then echo 'Environment variable CF_ORGANIZATION is undefined.'; return 1; fi
+# - CF_SPACE: IBM Cloud/Cluod Foundry space name
+if [ -z ${CF_SPACE+x} ]; then echo 'Environment variable CF_SPACE is undefined.'; return 1; fi
+# - APP_NAME: IBM Cloud/Cluod Foundry application name
+if [ -z ${APP_NAME+x} ]; then echo 'Environment variable APP_NAME is undefined.'; return 1; fi
+
+# set optional Cloud Foundry variables if they are not set
+# - CF_API: IBM Cloud API endpoint (default to US-South region)
+if [ -z ${CF_API+x} ]; then export CF_API='https://api.ng.bluemix.net'; fi
+
+# verify that the required application specific variables are set
+# - refer to documentation
+if [ -z ${CLOUDANT_URL+x} ]; then echo 'Environment variable CLOUDANT_URL is undefined.'; return 1; fi
+if [ -z ${CLOUDANT_DB+x} ]; then echo 'Environment variable CLOUDANT_DB is undefined.'; return 1; fi
+if [ -z ${SLACK_TOKEN+x} ]; then echo 'Environment variable SLACK_TOKEN is undefined.'; return 1; fi
+
 # login and set target
 ./Bluemix_CLI/bin/bluemix config --check-version false
-./Bluemix_CLI/bin/bluemix api https://api.ng.bluemix.net
+./Bluemix_CLI/bin/bluemix api $CF_API
 ./Bluemix_CLI/bin/bluemix login --apikey $BXIAM
 ./Bluemix_CLI/bin/bluemix target -o $CF_ORGANIZATION -s $CF_SPACE
 # push app but don't start it (app start will fail unless the following environment

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,14 +1,15 @@
 #!/bin/bash
 
 # verify that the required Cloud Foundry variables are set
+invocation_error=0
 # - BXIAM: IBM Cloud API key
-if [ -z ${BXIAM+x} ]; then echo 'Environment variable BXIAM is undefined.'; exit 1; fi
+if [ -z ${BXIAM+x} ]; then echo 'Error: Environment variable BXIAM is undefined.'; invocation_error=1; fi
 # - CF_ORGANIZATION: IBM Cloud/Cloud Foundry organization name
-if [ -z ${CF_ORGANIZATION+x} ]; then echo 'Environment variable CF_ORGANIZATION is undefined.'; exit 1; fi
+if [ -z ${CF_ORGANIZATION+x} ]; then echo 'Error: Environment variable CF_ORGANIZATION is undefined.'; invocation_error=1; fi
 # - CF_SPACE: IBM Cloud/Cluod Foundry space name
-if [ -z ${CF_SPACE+x} ]; then echo 'Environment variable CF_SPACE is undefined.'; exit 1; fi
+if [ -z ${CF_SPACE+x} ]; then echo 'Error: Environment variable CF_SPACE is undefined.'; invocation_error=1; fi
 # - APP_NAME: IBM Cloud/Cluod Foundry application name
-if [ -z ${APP_NAME+x} ]; then echo 'Environment variable APP_NAME is undefined.'; exit 1; fi
+if [ -z ${APP_NAME+x} ]; then echo 'Error: Environment variable APP_NAME is undefined.'; invocation_error=1; fi
 
 # set optional Cloud Foundry variables if they are not set
 # - CF_API: IBM Cloud API endpoint (default to US-South region)
@@ -16,9 +17,11 @@ if [ -z ${CF_API+x} ]; then export CF_API='https://api.ng.bluemix.net'; fi
 
 # verify that the required application specific variables are set
 # - refer to documentation
-if [ -z ${CLOUDANT_URL+x} ]; then echo 'Environment variable CLOUDANT_URL is undefined.'; exit 1; fi
-if [ -z ${CLOUDANT_DB+x} ]; then echo 'Environment variable CLOUDANT_DB is undefined.'; exit 1; fi
-if [ -z ${SLACK_TOKEN+x} ]; then echo 'Environment variable SLACK_TOKEN is undefined.'; exit 1; fi
+if [ -z ${CLOUDANT_URL+x} ]; then echo 'Error: Environment variable CLOUDANT_URL is undefined.'; invocation_error=1; fi
+if [ -z ${CLOUDANT_DB+x} ]; then echo 'Error: Environment variable CLOUDANT_DB is undefined.'; invocation_error=1; fi
+if [ -z ${SLACK_TOKEN+x} ]; then echo 'Error: Environment variable SLACK_TOKEN is undefined.'; invocation_error=1; fi
+
+if [ ${invocation_error} -eq 1 ]; then echo 'Aborting deployment.'; exit 1; fi
 
 # login and set target
 ./Bluemix_CLI/bin/bluemix config --check-version false

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,10 +1,16 @@
 #!/bin/bash
 
+# login and set target
 ./Bluemix_CLI/bin/bluemix config --check-version false
 ./Bluemix_CLI/bin/bluemix api https://api.ng.bluemix.net
 ./Bluemix_CLI/bin/bluemix login --apikey $BXIAM
 ./Bluemix_CLI/bin/bluemix target -o $CF_ORGANIZATION -s $CF_SPACE
+# push app but don't start it (app start will fail unless the following environment
+# variables are defined: CLOUDANT_URL, CLOUDANT_DB and SLACK_TOKEN
 ./Bluemix_CLI/bin/bluemix cf push $APP_NAME --no-start
+# set required environment variables
 ./Bluemix_CLI/bin/bluemix cf set-env $APP_NAME CLOUDANT_URL $CLOUDANT_URL
 ./Bluemix_CLI/bin/bluemix cf set-env $APP_NAME CLOUDANT_DB $CLOUDANT_DB
+./Bluemix_CLI/bin/bluemix cf set-env $APP_NAME SLACK_TOKEN $SLACK_TOKEN
+# start the app
 ./Bluemix_CLI/bin/bluemix cf start $APP_NAME

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+./Bluemix_CLI/bin/bluemix config --check-version false
+./Bluemix_CLI/bin/bluemix api https://api.ng.bluemix.net
+./Bluemix_CLI/bin/bluemix login --apikey $BXIAM
+./Bluemix_CLI/bin/bluemix target -o $CF_ORGANIZATION -s $CF_SPACE
+./Bluemix_CLI/bin/bluemix cf push $APP_NAME --no-start
+./Bluemix_CLI/bin/bluemix cf set-env $APP_NAME CLOUDANT_URL $CLOUDANT_URL
+./Bluemix_CLI/bin/bluemix cf set-env $APP_NAME CLOUDANT_DB $CLOUDANT_DB
+./Bluemix_CLI/bin/bluemix cf start $APP_NAME

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Stack Overflow Dashboard",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "echo \"Warning: no test specified\" && exit 0",
     "start": "node index.js"
   },
   "repository": {


### PR DESCRIPTION
To configure Travis CI deployment define the following environment variables:
- Required:
   - `BXIAM` - IBM Cloud API key
   - `CF_ORGANIZATION` - target IBM Cloud organization
   - `CF_SPACE` - target IBM Cloud space in `CF_ORGANIZATION`
   - `APP_NAME` - target application name in `CF_SPACE`
   - `CLOUDANT_URL` - see application configuration
   - `CLOUDANT_DB` - see application configuration
   - `SLACK_TOKEN` - see application configuration
- Optional:
   - `CF_API` - target IBM Cloud API endpoint (defaults to `https://api.ng.bluemix.net`)