### PR TITLE
give new users access to the events database on login - issue #107

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -16,6 +16,7 @@ var safeurl = parsed.protocol + '//' + parsed.host + '/' + SOdbname;
 // use silverlining to work on the databases
 var tokensdb = silverlining(url, 'tokens');
 var sodb = silverlining(url, SOdbname);
+var eventsdb = silverlining(url, 'events');
 
 // create databases, if they don't already exist
 var opts = { indexAll: false };
@@ -112,5 +113,6 @@ sodb.update(dashboarddoc).then(function() {
 module.exports = {
   tokens: tokensdb,
   so: sodb,
+  events: eventsdb,
   url: safeurl
 };

--- a/lib/db.js
+++ b/lib/db.js
@@ -22,7 +22,8 @@ var eventsdb = cloudantqs(url, 'events');
 var opts = { indexAll: false };
 Promise.all([
   tokensdb.create(opts),
-  sodb.create(opts)
+  sodb.create(opts),
+  eventsdb.create(opts)
 ]).then(function() {
   console.log('databases created');
 });

--- a/lib/db.js
+++ b/lib/db.js
@@ -1,6 +1,6 @@
 
 // dependencies
-var silverlining = require('silverlining');
+var cloudantqs = require('cloudant-quickstart');
 var URL = require('url');
 
 // extract the Cloudant URL from an environment variable
@@ -13,10 +13,10 @@ var parsed = URL.parse(url);
 var SOdbname = process.env.CLOUDANT_DB || 'questions';
 var safeurl = parsed.protocol + '//' + parsed.host + '/' + SOdbname;
 
-// use silverlining to work on the databases
-var tokensdb = silverlining(url, 'tokens');
-var sodb = silverlining(url, SOdbname);
-var eventsdb = silverlining(url, 'events');
+// use cloudant-quickstart to work on the databases
+var tokensdb = cloudantqs(url, 'tokens');
+var sodb = cloudantqs(url, SOdbname);
+var eventsdb = cloudantqs(url, 'events');
 
 // create databases, if they don't already exist
 var opts = { indexAll: false };
@@ -102,7 +102,7 @@ var dashboarddoc = {
   },
   language: "javascript"
 };
-console.log(dashboarddoc);
+
 sodb.update(dashboarddoc).then(function() {
   console.log('dashboard design doc created');
 });

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
   "dependencies": {
     "body-parser": "^1.17.1",
     "cfenv": "^1.0.4",
-    "express": "^4.15.2",
-    "silverlining": "^1.24.7"
+    "cloudant-quickstart": "^1.25.1",
+    "express": "^4.15.2"
   },
   "engines": {
     "node": ">=4.2.0"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "body-parser": "^1.17.1",
     "cfenv": "^1.0.4",
     "express": "^4.15.2",
-    "silverlining": "^1.23.2"
+    "silverlining": "^1.24.7"
   },
   "engines": {
     "node": ">=4.2.0"


### PR DESCRIPTION
When a user redeems their login token e.g. visit http://domain-name/login.html?329e4481cf790a55e6b54ebf3fd5d2a4 we:

- ensure the token is valid
- create a new Cloudant user
- give that user read/write/replicator access to the questions database
- returns the credentials to the user
- delete the token

This ticket also gives the new user access to the new `events` database too.

Note if this ticket is merged, we're going to need an "events" database. See issue #110 