### PR TITLE
add an event when a question is assigned and sync to Cloudant - issue #106

### DIFF
--- a/public/js/sodashboard.js
+++ b/public/js/sodashboard.js
@@ -519,7 +519,9 @@ var app = new Vue({
             assigned_at: new Date().toISOString(),
             assigned_to: doc.owner,
             assigned_to_name: app.userlist[doc.owner],
-            notified: false
+            notified: false,
+            question_id:  doc._id,
+            title: doc.question.title
           };
           return eventsdb.post(e);
 


### PR DESCRIPTION
When a question is assigned, a new document is added to the `events` PouchDB database, like so:

```js
{
  "_id": "53f6bd4f-849e-46d8-b7e5-d41923dc22fe",
  "_rev": "1-4ed835465fa844baa1ee5a5680f4f742",
  "type": "assigned",
  "assigned_by": "U7844223OL",
  "assigned_by_name": "stevie.smith",
  "assigned_at": "2018-02-08T08:53:58.518Z",
  "assigned_to": "U0Z2VN3EU",
  "assigned_to_name": "glynn.bird",
  "notified": false
}
```

PouchDB is then instructed to replicate to the remote Cloudant `events` database as a one-off operation. 

To test:

- make sure there is an `events` database on the Cloudant side see issue #108 
- open sodashboard from this branch
- assign a ticket to someone
- check that local events database contains some data - in the web developer console `eventsdb.allDocs({include_docs:true}).then(console.log)`
- look for log message indicating that replication completed - `events sync complete {ok: true, start_time: Thu Feb 08 2018 08:53:58 GMT+0000 (GMT), docs_read: 1, docs_written: 1, doc_write_failures: 0, …}`
- check the Cloudant side `events` database to see if the document arrived